### PR TITLE
Split-step generator improved

### DIFF
--- a/data/test_spst_gen.py
+++ b/data/test_spst_gen.py
@@ -5,19 +5,17 @@ import plotly.express as px
 from split_step_generator import SplitStepGenerator, transform_to_1d
 from plotly.offline import plot
 
-import time as time
-
 data_gen = SplitStepGenerator(batch_size=10,
-                          seq_len=32,
+                          seq_len=2049,
                           dispersion=0.5,
-                          nonlinearity=0.02,
+                          nonlinearity=0.5,
                           pulse_width=10,
                           z_end=100,
                           dz=0.1,
                           z_stride=1000,
-                          dim_t=2**12,
+                          dim_t=2**16,
                           dispersion_compensate=True,
-                          num_blocks = 16,
+                          num_blocks = 32,
                           n_train_batches = 1,
                           n_val_batches = 0,
                           n_test_batches = 0,
@@ -27,25 +25,32 @@ data_gen = SplitStepGenerator(batch_size=10,
                           pulse_amplitudes_seed=42,
                           )
 
-t0 = time.time()
 data_gen.prepare_data()
-t, z, u = data_gen.t, data_gen.z, data_gen.E
-print(time.time() - t0)
+t, z, u2d = data_gen.t, data_gen.z, data_gen.E
 
 t_start, t_end = data_gen.t_window
 
-u = transform_to_1d(u)
+u = transform_to_1d(u2d)
 
 I = abs(u * torch.conj(u)).type(torch.float32)
 
 # Plot first(0) batch
-fig = px.line(x=t[t_start:t_end], y=I[0,-1,t_start:t_end], title='Output intensity', labels={'x':'Time', 'y':'Intensity'})
+# fig = px.line(x=t[t_start:t_end], y=I[0,-1,t_start:t_end], title='Output intensity', labels={'x':'Time', 'y':'Intensity'})
+# plot(fig)
+
+# fig = px.line(x=t[t_start:t_end], y=u[0,0,t_start:t_end].real, title='Input', labels={'x':'Time', 'y':'real E'})
+# plot(fig)
+
+# fig = px.line(x=t[t_start:t_end], y=u[0,-1,t_start:t_end].real, title='Output', labels={'x':'Time', 'y':'real E'})
+# plot(fig)
+
+fig = px.line(x=t, y=I[0,-1,:], title='Output intensity', labels={'x':'Time', 'y':'Intensity'})
 plot(fig)
 
-fig = px.line(x=t[t_start:t_end], y=u[0,0,t_start:t_end].real, title='Input', labels={'x':'Time', 'y':'real E'})
+fig = px.line(x=t, y=u[0,0,:].real, title='Input', labels={'x':'Time', 'y':'real E'})
 plot(fig)
 
-fig = px.line(x=t[t_start:t_end], y=u[0,-1,t_start:t_end].real, title='Output', labels={'x':'Time', 'y':'real E'})
+fig = px.line(x=t, y=u[0,-1,:].real, title='Output', labels={'x':'Time', 'y':'real E'})
 plot(fig)
 
 # fig = go.Figure(data=[go.Surface(x=t, y=z, z=u.abs())])


### PR DESCRIPTION
Now input signal symmetric with respect to 0. The length of the sequence must be set odd, I set it to 2049, I suggest not changing this value for 2d data. The appropriate parameters for training on 2D data available in the test_spst_gen.py file, we need to transfer them to the config. Number of blocks changed to 32.